### PR TITLE
Fix for incorrect state change when recovering

### DIFF
--- a/src/main/scala/sample/blog/Post.scala
+++ b/src/main/scala/sample/blog/Post.scala
@@ -71,7 +71,7 @@ class Post(authorListing: ActorRef) extends PersistentActor with ActorLogging {
       context.become(created)
       state = state.updated(evt)
     case evt @ PostPublished =>
-      context.become(created)
+      context.become(published)
       state = state.updated(evt)
     case evt: Event => state =
       state.updated(evt)


### PR DESCRIPTION
During the recovery phase, the handling of PostPublished sets the actor into 'created' state. In fact, this should be 'published' state. This PR is just a one line fix that places the actor into the correct state.
